### PR TITLE
Add Go import comments.

### DIFF
--- a/errors/group.go
+++ b/errors/group.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package errors provides grouped errors.
-package errors
+package errors // import "sevki.org/x/errors"
 
 import (
 	"bytes"

--- a/names/names.go
+++ b/names/names.go
@@ -1,4 +1,4 @@
-package names
+package names // import "sevki.org/x/names"
 
 import (
 	"crypto/sha512"

--- a/reconcile/reconcile.go
+++ b/reconcile/reconcile.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package reconcile
+package reconcile // import "sevki.org/x/reconcile"
 
 import (
 	"bytes"

--- a/source/source.go
+++ b/source/source.go
@@ -1,4 +1,4 @@
-package source
+package source // import "sevki.org/x/source"
 
 import (
 	"regexp"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
